### PR TITLE
fix: well-known route

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,37 @@ docker-compose logs -f lnd
 docker-compose logs -f bitcoind
 ```
 
+### Bitkit Testing
+
+#### Bech32 LNURL Pay
+- checkout this repo locally
+- in `Env.kt`, change `ElectrumServers.REGTEST` to
+  ```
+  host = "__YOUR_NETWORK_IP__",
+  tcp = 60001,
+  ```
+- uninstall old app and install fresh one
+- set DOMAIN in `docker-compose.yml` to `http://__YOUR_NETWORK_IP__:3000`
+- run `docker compose up --build`
+- mine blocks: `./bitcoin-cli mine 101`
+- fund onchain wallet: `./bitcoin-cli send`
+- mine block: `./bitcoin-cli mine 1`
+- get local LND nodeID and open channel
+	- `http://localhost:3000/health`
+	- get nodeID from `lnd_info.uris` array, replace `127.0.0.1` with `__YOUR_NETWORK_IP__` and paste into app, then complete the flow
+	- `./bitcoin-cli mine 3`
+- generate LNURL pay: `http://localhost:3000/generate/pay`
+- paste lnurl into app
+- generate fixed amount LNURL pay (QuickPay): `http://localhost:3000/generate/pay?minSendable=10000&maxSendable=10000`
+
+#### Lightning Address
+- `ngrok http 3000`
+- change `DOMAIN` in `docker-compose.yml` to `__NGROK_URL__`
+- `docker compose down` if running
+- `docker compose up --build`
+- `http://localhost:3000/.well-known/lnurlp/alice`
+- copy the email-like lightning address and paste into app
+
 ## Configuration
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ docker-compose logs -f bitcoind
 - `http://localhost:3000/.well-known/lnurlp/alice`
 - copy the email-like lightning address and paste into app
 
+#### LNURL Channel
+- setup `docker-compose.yml`
+  - change `DOMAIN` to `http://__YOUR_NETWORK_IP__:3000`
+  - set lnd's `--externalip=127.0.0.1` to `--externalip=__YOUR_NETWORK_IP__`
+- reset old docker data
+  - `docker compose down --volumes`
+  - `rm -rf ./lnd ./lnurl-server/data`
+- `docker compose up --build`
+- mine blocks: `./bitcoin-cli mine 101`
+- fund LND wallet:
+  - get address: `curl -s http://localhost:3000/address | jq -r .address`
+  - fund LND wallet: `./bitcoin-cli send 0.2`
+  - mine block `./bitcoin-cli mine 1`
+- generate LNURL channel: `http://localhost:3000/channel`
+- paste lnurl into app and complete the flow
+- mine blocks: `./bitcoin-cli mine 6`
+
 ## Configuration
 
 ### Environment Variables
@@ -170,6 +187,14 @@ Key environment variables in `docker-compose.yml`:
 ### Nuke databases
 1. Run `docker compose down --volumes`
 2. Delete databases: `rm -rf ./lnd ./lnurl-server/data`
+
+### LNURL issues
+1. Check latest logs snapshot: `docker logs lnurl-server --tail 10`
+2. Check live logs: `docker-compose logs -f lnurl-server`
+3. Check LND wallet balance:
+```sh
+docker exec lnd lncli --network=regtest --tlscertpath=/home/lnd/.lnd/tls.cert --macaroonpath=/home/lnd/.lnd/data/chain/bitcoin/regtest/admin.macaroon walletbalance
+```
 
 ## Security Notes
 

--- a/lnurl-server/routes/admin.js
+++ b/lnurl-server/routes/admin.js
@@ -133,6 +133,12 @@ router.get('/payment/:paymentId/status', asyncHandler(async (req, res) => {
     }
 }));
 
+// Get new LND address for funding
+router.get('/address', asyncHandler(async (req, res) => {
+    const addressInfo = await lndService.getNewAddress();
+    res.json(addressInfo);
+}));
+
 // Helper function to check connections
 async function checkConnections() {
     const result = { bitcoin: false, lnd: false, error: null, blockHeight: null, nodeInfo: null };

--- a/lnurl-server/routes/generate.js
+++ b/lnurl-server/routes/generate.js
@@ -69,34 +69,4 @@ router.get('/:type', asyncHandler(async (req, res) => {
     }
 }));
 
-// LNURL-address resolution (well-known)
-router.get('/.well-known/lnurlp/:username', asyncHandler(async (req, res) => {
-    const { username } = req.params;
-
-    const domain = config.domain.replace(/^https?:\/\//, '');
-    const lightningAddress = `${username}@${domain}`;
-
-    // LUD-16 compliant metadata
-    const metadata = JSON.stringify([
-        ["text/plain", `Payment to ${lightningAddress}`],
-        ["text/identifier", lightningAddress]
-    ]);
-
-    const paymentId = require('crypto').createHash('sha256').update(username).digest('hex');
-
-    // Store or update payment configuration for this Lightning Address
-    await db.createPaymentConfig(paymentId, config.limits.minSendable, config.limits.maxSendable, 100);
-
-    Logger.info('Lightning Address config created', { username, paymentId });
-
-    res.json({
-        tag: 'payRequest',
-        callback: `${config.domain}/pay/${paymentId}/callback`,
-        minSendable: config.limits.minSendable,
-        maxSendable: config.limits.maxSendable,
-        metadata,
-        commentAllowed: config.limits.commentAllowed
-    });
-}));
-
 module.exports = router;

--- a/lnurl-server/routes/well-known.js
+++ b/lnurl-server/routes/well-known.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const router = express.Router();
+
+const config = require('../config');
+const db = require('../database');
+const Logger = require('../utils/logger');
+const { asyncHandler } = require('../middleware/errorHandler');
+
+// LNURL-address resolution (well-known)
+router.get('/.well-known/lnurlp/:username', asyncHandler(async (req, res) => {
+    const { username } = req.params;
+
+    const domain = config.domain.replace(/^https?:\/\//, '');
+    const lightningAddress = `${username}@${domain}`;
+
+    // LUD-16 compliant metadata
+    const metadata = JSON.stringify([
+        ["text/plain", `Payment to ${lightningAddress}`],
+        ["text/identifier", lightningAddress]
+    ]);
+
+    const paymentId = require('crypto').createHash('sha256').update(username).digest('hex');
+
+    // Store or update payment configuration for this Lightning Address
+    await db.createPaymentConfig(paymentId, config.limits.minSendable, config.limits.maxSendable, 100);
+
+    Logger.info('Lightning Address config created', { username, paymentId });
+
+    res.json({
+        tag: 'payRequest',
+        callback: `${config.domain}/pay/${paymentId}/callback`,
+        minSendable: config.limits.minSendable,
+        maxSendable: config.limits.maxSendable,
+        metadata,
+        commentAllowed: config.limits.commentAllowed
+    });
+}));
+
+module.exports = router; 

--- a/lnurl-server/server.js
+++ b/lnurl-server/server.js
@@ -13,6 +13,7 @@ const channelRoutes = require('./routes/channel');
 const payRoutes = require('./routes/pay');
 const adminRoutes = require('./routes/admin');
 const generateRoutes = require('./routes/generate');
+const wellKnownRoutes = require('./routes/well-known');
 
 // Create Express app
 const app = express();
@@ -35,6 +36,7 @@ app.use('/withdraw', withdrawRoutes);
 app.use('/channel', channelRoutes);
 app.use('/pay', payRoutes);
 app.use('/', adminRoutes); // Health check and monitoring endpoints
+app.use('/', wellKnownRoutes);
 app.use('/generate', generateRoutes);
 
 // Error handling middleware (must be last)

--- a/lnurl-server/services/lnd.js
+++ b/lnurl-server/services/lnd.js
@@ -141,6 +141,15 @@ class LNDService {
         }
     }
 
+    async getNewAddress() {
+        try {
+            return await this.rest('/v1/newaddress', 'GET');
+        } catch (error) {
+            console.error('Failed to get new address:', error.message);
+            throw error;
+        }
+    }
+
     async openChannel(nodePubkey, localFundingAmount, privateChannel = false) {
         try {
             const response = await this.rest('/v1/channels', 'POST', {


### PR DESCRIPTION
This PR moves well-known route to the root url instead of under `generate/`.

Needed for correct mapping of lightning address to the `.well-known` route.

### Test
1. `ngrok http 3000`
2. change `DOMAIN` in `docker-compose.yml`
3. `docker compose down` if running
4. `docker compose up --build`
5. `http://localhost:3000/.well-known/lnurlp/alice`
6. Copy the lightning address (eg. `alice@f6d14ff4c9f8.ngrok-free.app`) and paste into Bitkit